### PR TITLE
✨헤더 화면 뷰에 따른 컴포넌트 쪼개기

### DIFF
--- a/src/components/header/HeaderMobile.jsx
+++ b/src/components/header/HeaderMobile.jsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import styled from "@emotion/styled";
+import alarmIcon from "../../assets/headerIcon/alarmIcon.svg";
+import profileIcon from "../../assets/headerIcon/profileIcon.svg";
+import logo from "../../assets/headerIcon/buycationLogo.webp";
+import logoHover from "../../assets/headerIcon/buycationLogoHover.webp";
+import ButtonBasic from "../elements/ButtonBasic";
+import Alarm from "./Alarm";
+import { getCookies } from "../../core/cookie";
+import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { sendModalStatus } from "../../redux/modules/modal/modalSlice";
+import { __patchAlarmState } from "../../redux/modules/alarm/alarmSlice";
+
+const HeaderMobile = (props) => {
+  const { onAlarmCount } = props;
+  const tokenValue = getCookies("id");
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const modalStatus = useSelector((state) => state.generalModal.toggleModal);
+  const [alarmModal, setAlarmModal] = useState(false);
+
+  //alarm
+  const onClickAlarmModalHandler = () => {
+    setAlarmModal(true);
+  };
+
+  const onMoveSelectPageHandler = (postingId, alarmId) => {
+    setAlarmModal(false);
+    navigate(`/details/${postingId}`);
+    dispatch(__patchAlarmState(alarmId));
+  };
+
+  const onCloseAlarmModalHandler = () => {
+    setAlarmModal(false);
+  };
+
+  //헤더 아이콘 기능
+  const onMoveLoginHandler = () => {
+    navigate("/login");
+    dispatch(sendModalStatus(true));
+  };
+
+  const onClickMypageModalHandler = () => {
+    dispatch(sendModalStatus(!modalStatus));
+  };
+
+  return (
+    <HeaderDiv>
+      {tokenValue ? (
+        <>
+          {alarmModal ? (
+            <Icon>
+              <img
+                className={onAlarmCount ? "mainColor" : ""}
+                alt="alarm"
+                src={alarmIcon}
+                onClick={onClickAlarmModalHandler}
+              />
+              <Alarm
+                top="4rem"
+                left="0"
+                onMove={onMoveSelectPageHandler}
+                onClose={onCloseAlarmModalHandler}
+              />
+            </Icon>
+          ) : (
+            <Icon>
+              <img
+                className={onAlarmCount ? "mainColor" : ""}
+                alt="alarm"
+                src={alarmIcon}
+                onClick={onClickAlarmModalHandler}
+              />
+            </Icon>
+          )}
+          <Logo alt="바이케이션" onClick={() => navigate("/")} />
+          <img
+            alt="tapBar"
+            src={profileIcon}
+            onClick={onClickMypageModalHandler}
+          />
+        </>
+      ) : (
+        <>
+          <Logo alt="바이케이션" onClick={() => navigate("/")} />
+          <ButtonBasic
+            width="4rem"
+            height="2rem"
+            borderRadius="2rem"
+            _onClick={onMoveLoginHandler}
+          >
+            로그인
+          </ButtonBasic>
+        </>
+      )}
+    </HeaderDiv>
+  );
+};
+
+export default HeaderMobile;
+
+const HeaderDiv = styled.div`
+  height: 60px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem 1rem;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.main};
+`;
+
+const Logo = styled.div`
+  height: 2.8rem;
+  width: 12.5rem;
+  margin-bottom: 1rem;
+  background: url(${logo}) bottom/100% no-repeat;
+  :hover {
+    background: url(${logoHover}) bottom/100% no-repeat;
+  }
+`;
+
+const Icon = styled.div`
+  display: flex;
+  gap: 23px;
+  cursor: pointer;
+
+  .mainColor {
+    filter: ${({ theme }) => theme.colors.imgFilter};
+  }
+`;

--- a/src/components/header/HeaderMobile.jsx
+++ b/src/components/header/HeaderMobile.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import styled from "@emotion/styled";
 import alarmIcon from "../../assets/headerIcon/alarmIcon.svg";
 import profileIcon from "../../assets/headerIcon/profileIcon.svg";
@@ -10,30 +10,19 @@ import { getCookies } from "../../core/cookie";
 import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import { sendModalStatus } from "../../redux/modules/modal/modalSlice";
-import { __patchAlarmState } from "../../redux/modules/alarm/alarmSlice";
 
 const HeaderMobile = (props) => {
-  const { onAlarmCount } = props;
+  const {
+    onAlarmCount,
+    onClickAlarmModalHandler,
+    onMoveSelectPageHandler,
+    onCloseAlarmModalHandler,
+    onAlarmModal,
+  } = props;
   const tokenValue = getCookies("id");
   const navigate = useNavigate();
   const dispatch = useDispatch();
   const modalStatus = useSelector((state) => state.generalModal.toggleModal);
-  const [alarmModal, setAlarmModal] = useState(false);
-
-  //alarm
-  const onClickAlarmModalHandler = () => {
-    setAlarmModal(true);
-  };
-
-  const onMoveSelectPageHandler = (postingId, alarmId) => {
-    setAlarmModal(false);
-    navigate(`/details/${postingId}`);
-    dispatch(__patchAlarmState(alarmId));
-  };
-
-  const onCloseAlarmModalHandler = () => {
-    setAlarmModal(false);
-  };
 
   //헤더 아이콘 기능
   const onMoveLoginHandler = () => {
@@ -49,7 +38,7 @@ const HeaderMobile = (props) => {
     <HeaderDiv>
       {tokenValue ? (
         <>
-          {alarmModal ? (
+          {onAlarmModal ? (
             <Icon>
               <img
                 className={onAlarmCount ? "mainColor" : ""}

--- a/src/components/header/HeaderPc.jsx
+++ b/src/components/header/HeaderPc.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import styled from "@emotion/styled";
+import postingIcon from "../../assets/headerIcon/postingIcon.svg";
+import chattingIcon from "../../assets/headerIcon/chattingIcon.svg";
+import alarmIcon from "../../assets/headerIcon/alarmIcon.svg";
+import profileIcon from "../../assets/headerIcon/profileIcon.svg";
+import logo from "../../assets/headerIcon/buycationLogo.webp";
+import logoHover from "../../assets/headerIcon/buycationLogoHover.webp";
+import ButtonBasic from "../elements/ButtonBasic";
+import Alarm from "./Alarm";
+import { getCookies } from "../../core/cookie";
+import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import { sendModalStatus } from "../../redux/modules/modal/modalSlice";
+
+const HeaderPc = (props) => {
+  const {
+    onAlarmCount,
+    onClickAlarmModalHandler,
+    onMoveSelectPageHandler,
+    onCloseAlarmModalHandler,
+    onAlarmModal,
+  } = props;
+  const tokenValue = getCookies("id");
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const modalStatus = useSelector((state) => state.generalModal.toggleModal);
+
+  //헤더 아이콘 기능
+  const onMovePostingHandler = () => {
+    navigate("/posting");
+    dispatch(sendModalStatus(true));
+  };
+
+  const onMoveLoginHandler = () => {
+    navigate("/login");
+    dispatch(sendModalStatus(true));
+  };
+
+  const onClickMypageModalHandler = () => {
+    dispatch(sendModalStatus(!modalStatus));
+  };
+
+  return (
+    <HeaderDiv>
+      <Logo alt="바이케이션" onClick={() => navigate("/")} />
+      {tokenValue ? (
+        <Icon>
+          <img alt="posting" src={postingIcon} onClick={onMovePostingHandler} />
+          <img alt="chatting" src={chattingIcon} />
+          {onAlarmModal ? (
+            <>
+              <img
+                className={onAlarmCount ? "mainColor" : ""}
+                alt="alarm"
+                src={alarmIcon}
+                onClick={onClickAlarmModalHandler}
+              />
+              <Alarm
+                top="4rem"
+                right="0"
+                onMove={onMoveSelectPageHandler}
+                onClose={onCloseAlarmModalHandler}
+              />
+            </>
+          ) : (
+            <img
+              className={onAlarmCount ? "mainColor" : ""}
+              alt="alarm"
+              src={alarmIcon}
+              onClick={onClickAlarmModalHandler}
+            />
+          )}
+          <img
+            alt="profile"
+            src={profileIcon}
+            onClick={onClickMypageModalHandler}
+          />
+        </Icon>
+      ) : (
+        <ButtonBasic
+          width="4rem"
+          height="2rem"
+          borderRadius="2rem"
+          _onClick={onMoveLoginHandler}
+        >
+          로그인
+        </ButtonBasic>
+      )}
+    </HeaderDiv>
+  );
+};
+
+export default HeaderPc;
+
+const HeaderDiv = styled.div`
+  height: 60px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2rem;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.main};
+`;
+
+const Logo = styled.div`
+  height: 2.8rem;
+  width: 12.5rem;
+  margin-bottom: 1rem;
+  background: url(${logo}) bottom/100% no-repeat;
+  :hover {
+    background: url(${logoHover}) bottom/100% no-repeat;
+  }
+`;
+
+const Icon = styled.div`
+  display: flex;
+  gap: 23px;
+  cursor: pointer;
+
+  .mainColor {
+    filter: ${({ theme }) => theme.colors.imgFilter};
+  }
+`;

--- a/src/shared/layout/Header.jsx
+++ b/src/shared/layout/Header.jsx
@@ -1,19 +1,12 @@
 import React, { useEffect, useState } from "react";
-import styled from "@emotion/styled";
-import postingIcon from "../../assets/headerIcon/postingIcon.svg";
-import chattingIcon from "../../assets/headerIcon/chattingIcon.svg";
-import alarmIcon from "../../assets/headerIcon/alarmIcon.svg";
-import profileIcon from "../../assets/headerIcon/profileIcon.svg";
-import logo from "../../assets/headerIcon/buycationLogo.webp";
-import logoHover from "../../assets/headerIcon/buycationLogoHover.webp";
 import useWindowResize from "../../hooks/useWindowResize";
-import ButtonBasic from "../../components/elements/ButtonBasic";
+import UserModal from "../../components/header/UserModal";
+import HeaderPc from "../../components/header/HeaderPc";
+import HeaderMobile from "../../components/header/HeaderMobile";
 import { getCookies, removeCookies } from "../../core/cookie";
 import { useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
-import UserModal from "../../components/header/UserModal";
 import { sendModalStatus } from "../../redux/modules/modal/modalSlice";
-import Alarm from "../../components/header/Alarm";
 import {
   __getAlarmCount,
   __patchAlarmState,
@@ -24,9 +17,9 @@ const Header = () => {
   const tokenValue = getCookies("id");
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const modalStatus = useSelector((state) => state.generalModal.toggleModal);
   const { alarmCount } = useSelector((data) => data?.alarm);
   const ALARMCOUNT = Number(alarmCount) >= 1;
-  const modalStatus = useSelector((state) => state.generalModal.toggleModal);
   const [alarmModal, setAlarmModal] = useState(false);
 
   //알람 갯수
@@ -36,7 +29,7 @@ const Header = () => {
     }
   }, [dispatch, tokenValue]);
 
-  //alarm
+  //alarm 조회, 삭제, 수정
   const onClickAlarmModalHandler = () => {
     setAlarmModal(true);
   };
@@ -49,19 +42,17 @@ const Header = () => {
     setAlarmModal(false);
   };
 
-  //헤더 아이콘 기능
+  //헤더 사람 아이콘 모달 내용 기능
   const onMovePostingHandler = () => {
     navigate("/posting");
     dispatch(sendModalStatus(true));
   };
+
   const onMoveMyProfileHandler = () => {
     navigate("/myprofile");
     dispatch(sendModalStatus(true));
   };
-  const onMoveLoginHandler = () => {
-    navigate("/login");
-    dispatch(sendModalStatus(true));
-  };
+
   const onMoveLogoutHandler = () => {
     removeCookies("id", {
       path: "/",
@@ -69,114 +60,27 @@ const Header = () => {
     navigate("/");
     dispatch(sendModalStatus(true));
   };
-  const onClickMypageModalHandler = () => {
-    dispatch(sendModalStatus(!modalStatus));
-  };
 
   return (
     <>
       {innerWidth > 768 ? (
-        <HeaderDiv>
-          <Logo alt="바이케이션" onClick={() => navigate("/")} />
-          {tokenValue ? (
-            <Icon>
-              <img
-                alt="posting"
-                src={postingIcon}
-                onClick={onMovePostingHandler}
-              />
-              <img alt="chatting" src={chattingIcon} />
-              {alarmModal ? (
-                <>
-                  <img
-                    className={ALARMCOUNT ? "mainColor" : ""}
-                    alt="alarm"
-                    src={alarmIcon}
-                    onClick={onClickAlarmModalHandler}
-                  />
-                  <Alarm
-                    top="4rem"
-                    right="0"
-                    onMove={onMoveSelectPageHandler}
-                    onClose={onCloseAlarmModalHandler}
-                  />
-                </>
-              ) : (
-                <img
-                  className={ALARMCOUNT ? "mainColor" : ""}
-                  alt="alarm"
-                  src={alarmIcon}
-                  onClick={onClickAlarmModalHandler}
-                />
-              )}
-              <img
-                alt="profile"
-                src={profileIcon}
-                onClick={onClickMypageModalHandler}
-              />
-            </Icon>
-          ) : (
-            <ButtonBasic
-              width="4rem"
-              height="2rem"
-              borderRadius="2rem"
-              _onClick={onMoveLoginHandler}
-            >
-              로그인
-            </ButtonBasic>
-          )}
-        </HeaderDiv>
+        <HeaderPc
+          onAlarmCount={ALARMCOUNT}
+          onClickAlarmModalHandler={onClickAlarmModalHandler}
+          onMoveSelectPageHandler={onMoveSelectPageHandler}
+          onCloseAlarmModalHandler={onCloseAlarmModalHandler}
+          onAlarmModal={alarmModal}
+        />
       ) : (
-        <HeaderDiv>
-          {tokenValue ? (
-            <>
-              {alarmModal ? (
-                <Icon>
-                  <img
-                    className={ALARMCOUNT ? "mainColor" : ""}
-                    alt="alarm"
-                    src={alarmIcon}
-                    onClick={onClickAlarmModalHandler}
-                  />
-                  <Alarm
-                    top="4rem"
-                    left="0"
-                    onMove={onMoveSelectPageHandler}
-                    onClose={onCloseAlarmModalHandler}
-                  />
-                </Icon>
-              ) : (
-                <Icon>
-                  <img
-                    className={ALARMCOUNT ? "mainColor" : ""}
-                    alt="alarm"
-                    src={alarmIcon}
-                    onClick={onClickAlarmModalHandler}
-                  />
-                </Icon>
-              )}
-              <Logo alt="바이케이션" onClick={() => navigate("/")} />
-              <img
-                alt="tapBar"
-                src={profileIcon}
-                onClick={onClickMypageModalHandler}
-              />
-            </>
-          ) : (
-            <>
-              <Logo alt="바이케이션" onClick={() => navigate("/")} />
-              <ButtonBasic
-                width="4rem"
-                height="2rem"
-                borderRadius="2rem"
-                _onClick={onMoveLoginHandler}
-              >
-                로그인
-              </ButtonBasic>
-            </>
-          )}
-        </HeaderDiv>
+        <HeaderMobile
+          onAlarmCount={ALARMCOUNT}
+          onClickAlarmModalHandler={onClickAlarmModalHandler}
+          onMoveSelectPageHandler={onMoveSelectPageHandler}
+          onCloseAlarmModalHandler={onCloseAlarmModalHandler}
+          onAlarmModal={alarmModal}
+        />
       )}
+
       {!modalStatus && (
         <UserModal
           top="4rem"
@@ -194,35 +98,3 @@ const Header = () => {
 };
 
 export default Header;
-
-const HeaderDiv = styled.div`
-  height: 60px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 2rem;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.main};
-  @media screen and (max-width: 768px) {
-    padding: 2rem 1rem;
-  }
-`;
-
-const Logo = styled.div`
-  height: 2.8rem;
-  width: 12.5rem;
-  margin-bottom: 1rem;
-  background: url(${logo}) bottom/100% no-repeat;
-  :hover {
-    background: url(${logoHover}) bottom/100% no-repeat;
-  }
-`;
-
-const Icon = styled.div`
-  display: flex;
-  gap: 23px;
-  cursor: pointer;
-
-  .mainColor {
-    filter: ${({ theme }) => theme.colors.imgFilter};
-  }
-`;


### PR DESCRIPTION
## PR 체크사항

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
헤더 화면 뷰에 따른 컴포넌트 쪼개보았습니다! 먼저
헤더 저희가 현재 헤더 화면 뷰에 따라 스타일만 변경되는 형식이 아닌 Return문 자체 내용(컴포넌트 및 요소 etc)이 달라지는 상황이다 보니 컴포넌트를 pc뷰와 모바일 뷰로 쪼개는게 어떤가 생각해보았습니다.
즉, 스타일은 두 컴포넌트가 비슷하지만 return문 안에 있는 내용들은 다른 컴포넌트가 생성되었습니다.

여기서 고민되었던 부분이 알림데이터를 리덕스에서 상태값을 읽어오는 부분이였는데 동일한 두 작업을 각각 컴포넌트에서 똑같이 코드를 작성해야할지 헤더부분에서 한번 불러오고 props로 내려줄지 고민하다 2번째 방법으로 해보았습니다!
이부분에 대해서 의견을 여쭈봐도 될까요? 🫶


## 작업사항
- 화면 뷰에 따른 헤더 컴포넌트 쪼개기

