### PR TITLE
🐛fix: 미로그인 시 500 getProfile rejected 해결

### DIFF
--- a/src/components/detail/DetailCommentForm.jsx
+++ b/src/components/detail/DetailCommentForm.jsx
@@ -15,12 +15,14 @@ import {
 import Swal from "sweetalert2";
 import ButtonBasic from "../elements/ButtonBasic";
 import { useParams } from "react-router-dom";
+import { getCookies } from "../../core/cookie";
 
 const DetailCommentForm = ({ className, commentId, commentContent }) => {
   const dispatch = useDispatch();
+  const tokenValue = getCookies("id");
   const postingId = parseInt(useParams().postingId);
   const [comment, setComment] = useState({ content: commentContent });
-  const myInfo = useSelector((state) => state.profile.getProfile);
+  const myInfo = useSelector((state) => state.profile?.getProfile);
   const isSuccess = useSelector((state) => state.comments.isSuccess);
   const toggleComment = useSelector((state) => state.comments.toggleComment);
 
@@ -61,7 +63,7 @@ const DetailCommentForm = ({ className, commentId, commentContent }) => {
   };
 
   useEffect(() => {
-    dispatch(__getMyProfile());
+    tokenValue && dispatch(__getMyProfile());
   }, [dispatch]);
 
   return (


### PR DESCRIPTION
- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
미로그인 시 500 getProfile rejected 해결


## 작업사항
- 토큰 없는 상황에서 getProfile을 dispatch하지 않도록 처리


## 연결 이슈 close
close #55 
