### PR TITLE
♻️refzctor : 알림 삭제 리펙토링

### DIFF
--- a/src/components/header/Alarm.jsx
+++ b/src/components/header/Alarm.jsx
@@ -6,7 +6,6 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   __getAlarmList,
   __deleteAlarm,
-  __deleteState,
   __deleteTotalAlarm,
 } from "../../redux/modules/alarm/alarmSlice";
 import { useEffect } from "react";
@@ -19,21 +18,12 @@ const Alarm = (props) => {
   const alarmListData = useSelector((data) => data.alarm);
   const alarmList = alarmListData.alarmList.dataList;
   const alarmKey = alarmListData.alarmKey; //무한 스크롤 시 사용될 예정 현재는 ""만 보냄
-  // const { deleteState } = useSelector((state) => state.alarm);
-  // console.log(alarmList);
 
   useEffect(() => {
     if (tokenValue) {
       dispatch(__getAlarmList(alarmKey));
     }
   }, [dispatch, tokenValue]);
-
-  // useEffect(() => {
-  //   if (deleteState) {
-  //     dispatch(__getAlarmList(alarmKey));
-  //     dispatch(__deleteState(false));
-  //   }
-  // }, [dispatch, deleteState]);
 
   const onClickDeleteAlarmHandler = (alarmId, index) => {
     dispatch(__deleteAlarm({ alarmId, index }));

--- a/src/components/header/Alarm.jsx
+++ b/src/components/header/Alarm.jsx
@@ -19,7 +19,7 @@ const Alarm = (props) => {
   const alarmListData = useSelector((data) => data.alarm);
   const alarmList = alarmListData.alarmList.dataList;
   const alarmKey = alarmListData.alarmKey; //무한 스크롤 시 사용될 예정 현재는 ""만 보냄
-  const { deleteState } = useSelector((state) => state.alarm);
+  // const { deleteState } = useSelector((state) => state.alarm);
   // console.log(alarmList);
 
   useEffect(() => {
@@ -28,15 +28,15 @@ const Alarm = (props) => {
     }
   }, [dispatch, tokenValue]);
 
-  useEffect(() => {
-    if (deleteState) {
-      dispatch(__getAlarmList(alarmKey));
-      dispatch(__deleteState(false));
-    }
-  }, [dispatch, deleteState]);
+  // useEffect(() => {
+  //   if (deleteState) {
+  //     dispatch(__getAlarmList(alarmKey));
+  //     dispatch(__deleteState(false));
+  //   }
+  // }, [dispatch, deleteState]);
 
-  const onClickDeleteAlarmHandler = (alarmId) => {
-    dispatch(__deleteAlarm(alarmId));
+  const onClickDeleteAlarmHandler = (alarmId, index) => {
+    dispatch(__deleteAlarm({ alarmId, index }));
   };
 
   const onClickDeleteTotalAlarmListHandler = (alarmId) => {
@@ -56,7 +56,7 @@ const Alarm = (props) => {
           {alarmList?.length === 0 ? (
             <EmptyAlarmListBox>새로운 알림이 없습니다.</EmptyAlarmListBox>
           ) : (
-            alarmList?.map((item) => (
+            alarmList?.map((item, index) => (
               <PerAlarm key={item.alarmId}>
                 <article>
                   <div onClick={() => onMove(item.postingId, item.alarmId)}>
@@ -70,7 +70,7 @@ const Alarm = (props) => {
                 <img
                   alt="alarmClose"
                   src={alarmClose}
-                  onClick={() => onClickDeleteAlarmHandler(item.alarmId)}
+                  onClick={() => onClickDeleteAlarmHandler(item.alarmId, index)}
                 />
               </PerAlarm>
             ))

--- a/src/redux/modules/alarm/alarmSlice.js
+++ b/src/redux/modules/alarm/alarmSlice.js
@@ -97,7 +97,9 @@ export const alarmSlice = createSlice({
       console.log(action.payload.index);
       state.isLoading = false;
       // state.deleteState = true;
-      state.alarmList = [...state.alarmList.splice(action.payload.index, 1)];
+      state.alarmList = [
+        ...state.alarmList.dataList.splice(action.payload.index, 1),
+      ];
     });
     builder.addCase(__patchAlarmState.fulfilled, (state, action) => {
       state.isLoading = false;

--- a/src/redux/modules/alarm/alarmSlice.js
+++ b/src/redux/modules/alarm/alarmSlice.js
@@ -5,8 +5,6 @@ const initialState = {
   alarmCount: 0,
   alarmList: [],
   alarmKey: "",
-  deleteState: false,
-
   isLoading: false,
   error: null,
 };
@@ -75,18 +73,14 @@ export const __deleteTotalAlarm = createAsyncThunk(
 export const alarmSlice = createSlice({
   name: "alarm",
   initialState,
-  reducers: {
-    __deleteState: (state, action) => {
-      state.deleteState = action.payload;
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder.addCase(__getAlarmCount.fulfilled, (state, action) => {
       state.isLoading = false;
       state.alarmCount = action.payload;
     });
     builder.addCase(__getAlarmList.fulfilled, (state, action) => {
-      console.log(action.payload);
+      //console.log(action.payload);
       state.isLoading = false;
       state.alarmList = action.payload;
       // if (action.payload.nextPageRequest) {
@@ -94,9 +88,8 @@ export const alarmSlice = createSlice({
       // }
     });
     builder.addCase(__deleteAlarm.fulfilled, (state, action) => {
-      console.log(action.payload.index);
+      //console.log(action.payload.index);
       state.isLoading = false;
-      // state.deleteState = true;
       state.alarmList = [
         ...state.alarmList.dataList.splice(action.payload.index, 1),
       ];
@@ -112,5 +105,4 @@ export const alarmSlice = createSlice({
   },
 });
 
-export const { __deleteState } = alarmSlice.actions;
 export default alarmSlice.reducer;

--- a/src/redux/modules/alarm/alarmSlice.js
+++ b/src/redux/modules/alarm/alarmSlice.js
@@ -38,9 +38,10 @@ export const __getAlarmList = createAsyncThunk(
 export const __deleteAlarm = createAsyncThunk(
   "deleteAlarm/delete",
   async (payload, thunkAPI) => {
+    console.log(payload);
     try {
-      const data = await baseURLwToken.delete(`alarm/${payload}`);
-      return thunkAPI.fulfillWithValue(data.data);
+      const data = await baseURLwToken.delete(`alarm/${payload.alarmId}`);
+      return thunkAPI.fulfillWithValue({ ...data.data, index: payload.index });
     } catch (error) {
       return thunkAPI.rejectWithValue(error);
     }
@@ -85,6 +86,7 @@ export const alarmSlice = createSlice({
       state.alarmCount = action.payload;
     });
     builder.addCase(__getAlarmList.fulfilled, (state, action) => {
+      console.log(action.payload);
       state.isLoading = false;
       state.alarmList = action.payload;
       // if (action.payload.nextPageRequest) {
@@ -92,8 +94,10 @@ export const alarmSlice = createSlice({
       // }
     });
     builder.addCase(__deleteAlarm.fulfilled, (state, action) => {
+      console.log(action.payload.index);
       state.isLoading = false;
-      state.deleteState = true;
+      // state.deleteState = true;
+      state.alarmList = [...state.alarmList.splice(action.payload.index, 1)];
     });
     builder.addCase(__patchAlarmState.fulfilled, (state, action) => {
       state.isLoading = false;


### PR DESCRIPTION
## PR 체크사항

- [x] 커밋 제목 규칙
- [x] 커밋 메시지 작성 가이드라인
- [x] 라벨, 담당자, 리뷰어 지정


## PR 타입

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:


## PR 설명
기존에 구현했던 방식은 알림 삭제 이벤트가 일어나면 삭제 API를 보내고 다시 응답 상태값을 통해 재렌더링 순간에 알림 전체 조회 리스트를 다시 받아옴! -> 통신을 한번 더하는 비효율적인 방식
따라서 삭제 이벤트가 발생하면 API를 보내고 리덕스에서 해당 조회리스트에서 삭제하는 알림을 제외하여 리스트를 뿌려줘서 한번 더 전체 조회리스트 API를 거치는 단계는 제외함


## 작업사항
- 알림 삭제 리펙토링

